### PR TITLE
Updated to using argparse, exception for when status is missing from pbs...

### DIFF
--- a/bin/qhost
+++ b/bin/qhost
@@ -14,48 +14,48 @@
 # limitations under the License.
 import os
 import sys
-import argparse
+from optparse import OptionParser
 
-VERSION = '1.0.1'
+VERSION = '1.0.0'
 
-def get_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
+def get_options():
+    parser = OptionParser()
+    parser.add_option(
         "-c", "--color",
         action="store_true", dest="color", default=False,
         help="turn on colorized output")
-    parser.add_argument(
+    parser.add_option(
         "-j", "--jobs",
         action="store_true", dest="jobs", default=False,
         help="show job information")
-    parser.add_argument(
+    parser.add_option(
         "-v", "--version",
         action="store_true", dest="version", default=False,
         help="Print version and exit.")
 
-    args = parser.parse_args()
+    (options, args) = parser.parse_args()
 
-    if args.version:
+    if options.version:
         print "qhost version", VERSION
         sys.exit(0)
 
-    return args
+    return options
 
-def run(args):
+def run(options):
     lib_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../')
     if lib_path not in sys.path:
         sys.path.insert(0, lib_path)
     import qhost
 
-    pbsnodes = qhost.Pbsnodes("pbsnodes")
+    pbsnodes = qhost.Pbsnodes("/usr/bin/pbsnodes")
     xml = pbsnodes.execute()
     qp = qhost.Parser(xml)
     nodes = qp.parse()
-    display = qhost.Display(color=args.color, showjobs=args.jobs)
+    display = qhost.Display(color=options.color, showjobs=options.jobs)
     display.list(nodes)
 
 def main():
-    run(get_args())    
+    run(get_options())    
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
...nodes, pbsnodes instead of absolute path

Hi @rlyon , nice tool! I updated to using argparse, and I put in an exception for status because the version of pbsnodes I have does not have that attribute.

The colors are nice.
Here's a pull request if you think it is worth it.
